### PR TITLE
Add ConnectionDone error to list for retrying

### DIFF
--- a/txwebretry.py
+++ b/txwebretry.py
@@ -15,7 +15,7 @@ Usage:
 
 from itertools import repeat
 from twisted.internet.error import ConnectionRefusedError, \
-        ConnectingCancelledError, TimeoutError
+        ConnectingCancelledError, ConnectionDone, TimeoutError
 from twisted.web.client import ResponseFailed
 from txretry.retry import RetryingCall, simpleBackoffIterator
 
@@ -28,6 +28,7 @@ class Retry(object):
             ResponseFailed,
             ConnectionRefusedError,
             ConnectingCancelledError,
+            ConnectionDone,
             TimeoutError]
 
     def __init__(self, backoff_func, *backoff_args, **backoff_kwargs):


### PR DESCRIPTION
Failures like this:

``` python
twisted.python.failure.Failure twisted.internet.error.ConnectionDone: Connection was closed cleanly
```

.. tend to occur during temporary connection failures. I think we should retry on these errors. Below is the full stacktrace for the error:

{"level": "error", "msg": "Error caught by error handler", "namespace": "consumer_api.endpoints", "log_failure": {"count": 2251, "captureVars": false, "tb": null, "pickled": 1, "value": {"unpersistable": true}, "parents": ["consumer_api.clients.auth_client.AuthServiceFailed", "consumer_api.clients.request_maker.ServiceFailed", "exceptions.Exception", "exceptions.BaseException", "**builtin**.object"], "frames": [["_inlineCallbacks", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 1126, [], []], ["throwExceptionIntoGenerator", "/usr/local/lib/python2.7/dist-packages/twisted/python/failure.py", 389, [], []], ["auth_bankid", "/usr/local/lib/python2.7/dist-packages/consumer_api/endpoints.py", 728, [], []], ["_inlineCallbacks", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 1126, [], []], ["throwExceptionIntoGenerator", "/usr/local/lib/python2.7/dist-packages/twisted/python/failure.py", 389, [], []], ["bankid_auth", "/usr/local/lib/python2.7/dist-packages/consumer_api/clients/auth_client.py", 107, [], []], ["_runCallbacks", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 588, [], []], ["_error_handler", "/usr/local/lib/python2.7/dist-packages/consumer_api/clients/request_maker.py", 68, [], []]], "__class_uuid__": "e76887e2-20ed-49bf-a8f8-ba25cc586f2d", "type": {"**name**": "AuthServiceFailed", "**module**": "consumer_api.clients.auth_client"}, "stack": [["<module>", "/usr/local/bin/consumer-api", 11, [], []], ["main", "/usr/local/lib/python2.7/dist-packages/consumer_api/**init**.py", 17, [], []], ["run", "/usr/local/lib/python2.7/dist-packages/twisted/internet/base.py", 1194, [], []], ["mainLoop", "/usr/local/lib/python2.7/dist-packages/twisted/internet/base.py", 1206, [], []], ["doPoll", "/usr/local/lib/python2.7/dist-packages/twisted/internet/epollreactor.py", 396, [], []], ["callWithLogger", "/usr/local/lib/python2.7/dist-packages/twisted/python/log.py", 101, [], []], ["callWithContext", "/usr/local/lib/python2.7/dist-packages/twisted/python/log.py", 84, [], []], ["callWithContext", "/usr/local/lib/python2.7/dist-packages/twisted/python/context.py", 118, [], []], ["callWithContext", "/usr/local/lib/python2.7/dist-packages/twisted/python/context.py", 81, [], []], ["_doReadOrWrite", "/usr/local/lib/python2.7/dist-packages/twisted/internet/posixbase.py", 610, [], []], ["_disconnectSelectable", "/usr/local/lib/python2.7/dist-packages/twisted/internet/posixbase.py", 252, [], []], ["readConnectionLost", "/usr/local/lib/python2.7/dist-packages/twisted/internet/tcp.py", 273, [], []], [**"connectionLost"**, "/usr/local/lib/python2.7/dist-packages/twisted/internet/tcp.py", 479, [], []], [**"connectionLost"**, "/usr/local/lib/python2.7/dist-packages/twisted/internet/tcp.py", 293, [], []], [**"connectionLost"**, "/usr/local/lib/python2.7/dist-packages/twisted/internet/endpoints.py", 116, [], []], ["dispatcher", "/usr/local/lib/python2.7/dist-packages/twisted/web/_newclient.py", 916, [], []], ["_connectionLost_WAITING", "/usr/local/lib/python2.7/dist-packages/twisted/web/_newclient.py", 1591, [], []], ["_disconnectParser", "/usr/local/lib/python2.7/dist-packages/twisted/web/_newclient.py", 1513, [], []], ["connectionLost", "/usr/local/lib/python2.7/dist-packages/twisted/web/_newclient.py", 549, [], []], ["errback", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 434, [], []], ["_startRunCallbacks", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 501, [], []], ["_runCallbacks", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 588, [], []], ["errback", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 434, [], []], ["_startRunCallbacks", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 501, [], []], ["_runCallbacks", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 588, [], []], ["gotResult", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 1184, [], []], ["_inlineCallbacks", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 1174, [], []], ["errback", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 434, [], []], ["_startRunCallbacks", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 501, [], []], ["_runCallbacks", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 588, [], []], ["gotResult", "/usr/local/lib/python2.7/dist-packages/twisted/internet/defer.py", 1184, [], []]]}, "response": "{\"status\": \"error\", \"message\": \"('http://auth.service/v1/bankid/auth', ' ', '[<twisted.python.failure.Failure twisted.internet.error.ConnectionDone: Connection was closed cleanly.>]', ' ', 'Traceback (most recent call last):\\nFailure: twisted.web._newclient.ResponseNeverReceived: [<**twisted.python.failure.Failure twisted.internet.error.ConnectionDone: Connection was closed cleanly**.>]\\n')\", \"type\": \"AuthServiceFailed\"}"} 
